### PR TITLE
Time format description update

### DIFF
--- a/setup/env-variables.mdx
+++ b/setup/env-variables.mdx
@@ -45,7 +45,8 @@ The following variables are set for the [Gnosis Chain Blockscout Instance](https
 
 ## Time format
 
-Can be set in format `1h` for 1 hour, `1m` for 1 minute, `1s` or `1` for 1 second, `1ms` for 1 millisecond
+Can be set in format `1h` for 1 hour, `1m` for 1 minute, `1s` or `1` for 1 second, `1ms` for 1 millisecond.
+If no unit is provided, the value will be interpreted as seconds.
 
 <Warning>
   _Note_: **Before release 5.1.2, all environment variables of time format supported only integers in seconds (without dimensions) as values.**

--- a/setup/env-variables/backend-env-variables.mdx
+++ b/setup/env-variables/backend-env-variables.mdx
@@ -72,7 +72,8 @@ title: "Backend ENVs: Common"
 
 ## Time format
 
-Can be set in format `1d` for 1 day, `1h` for 1 hour, `1m` for 1 minute, `1s` or `1` for 1 second, `1ms` for 1 millisecond
+Can be set in format `1d` for 1 day, `1h` for 1 hour, `1m` for 1 minute, `1s` or `1` for 1 second, `1ms` for 1 millisecond.
+If no unit is provided, the value will be interpreted as seconds.
 
 <Warning>
   **_Note_** **: Before release 5.1.2, all environment variables of time format supported only integers in seconds (without dimensions) as values.**

--- a/setup/env-variables/backend-envs-chain-specific.mdx
+++ b/setup/env-variables/backend-envs-chain-specific.mdx
@@ -61,7 +61,8 @@ You can browse all available image variants in the [Blockscout GitHub Packages r
 
 ## Time format
 
-Can be set in format `1h` for 1 hour, `1m` for 1 minute, `1s` or `1` for 1 second, `1ms` for 1 millisecond
+Can be set in format `1h` for 1 hour, `1m` for 1 minute, `1s` or `1` for 1 second, `1ms` for 1 millisecond.
+If no unit is provided, the value will be interpreted as seconds.
 
 <Warning>
 ***Note*** **: Before release 5.1.2, all environment variables of time format supported only integers in seconds (without dimensions) as values.**

--- a/setup/env-variables/backend-envs-integrations.mdx
+++ b/setup/env-variables/backend-envs-integrations.mdx
@@ -10,7 +10,8 @@ title: "Backend ENVs: Integrations"
 
 ## Time format
 
-Can be set in format `1h` for 1 hour, `1m` for 1 minute, `1s` or `1` for 1 second, `1ms` for 1 millisecond
+Can be set in format `1h` for 1 hour, `1m` for 1 minute, `1s` or `1` for 1 second, `1ms` for 1 millisecond.
+If no unit is provided, the value will be interpreted as seconds.
 
 <Warning>
   **_Note_** **: Before release 5.1.2, all environment variables of time format supported only integers in seconds (without dimensions) as values.**


### PR DESCRIPTION
Extend description with: "If no unit is provided, the value will be interpreted as seconds.".