### PR TITLE
Sourcify: migrate to API v2 new envs

### DIFF
--- a/setup/env-variables/backend-envs-integrations.mdx
+++ b/setup/env-variables/backend-envs-integrations.mdx
@@ -154,11 +154,13 @@ If no unit is provided, the value will be interpreted as seconds.
   Allows for contract verification via [Sourcify](https://sourcify.dev/)
 </Info>
 
-| Variable                       | Description                                                     | Parameters                                                                                                                                                      |
-| ------------------------------ | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `SOURCIFY_INTEGRATION_ENABLED` | Enables or disables verification of contracts through Sourcify. | Version: v5.1.3+ <br />Default: `false` <br />Applications: API                                                                                                 |
-| `SOURCIFY_SERVER_URL`          | URL to Sourcify backend.                                        | Version: v3.7.0+ <br />Default: `https://sourcify.dev/server` <br />Applications: API                                                                           |
-| `SOURCIFY_REPO_URL`            | URL to Sourcify repository with fully verified contracts.       | Version: v3.7.0+ <br />Default: `https://repo.sourcify.dev/contracts/` Before v3.7.1: `https://repo.sourcify.dev/contracts/full_match/` <br />Applications: API |
+| Variable                       | Description                                                                                                              | Parameters                                                                                                                        |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| `SOURCIFY_INTEGRATION_ENABLED` | Enables or disables verification of contracts through Sourcify.                                                          | Version: v5.1.3+ <br />Default: `false` <br />Applications: API                                                                   |
+| `SOURCIFY_SERVER_URL`          | URL to Sourcify backend.                                                                                                 | Version: v3.7.0+ <br />Default: `https://sourcify.dev/server` <br />Applications: API                                             |
+| `SOURCIFY_REPO_URL`            | URL to Sourcify repository with fully verified contracts. Override the env var if a custom repository URL is set.        | Version: v3.7.0+ <br />Default: `https://repo.sourcify.dev/` <br />Applications: API                                              |
+| `SOURCIFY_POLL_INTERVAL`       | Interval between async verification polling requests. [Time format](/setup/env-variables/backend-env-variables#time-format). Implemented in [#14584](https://github.com/blockscout/blockscout/pull/14584). | Version: latest <br />Default: `3s` <br />Applications: API                |
+| `SOURCIFY_POLL_MAX_ATTEMPTS`   | Maximum number of attempts for async verification polling. Implemented in [#14584](https://github.com/blockscout/blockscout/pull/14584)                                                                    | Version: latest <br />Default: `20` <br />Applications: API                |
 
 ## Tenderly
 


### PR DESCRIPTION
New runtime envs for https://github.com/blockscout/blockscout/pull/14584